### PR TITLE
Remove `ExpressibleByStringLiteral` conformance of `Regex` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Deprecated
 - None.
 ### Removed
-- None.
+- Remove `ExpressibleByStringLiteral` conformance of `Regex` type to only allow initialization via `init(_:options:) throws` interface.
 ### Fixed
 - None.
 ### Security

--- a/Frameworks/HandySwift/Structs/Regex.swift
+++ b/Frameworks/HandySwift/Structs/Regex.swift
@@ -101,23 +101,6 @@ public struct Regex {
     }
 }
 
-// MARK: - ExpressibleByStringLiteral
-extension Regex: ExpressibleByStringLiteral {
-    @available(*, deprecated, message: "Use `init(_:options:) throws` instead.")
-    /// Creates a new `Regex` based on a string literal.
-    /// If the internal initialization fails, the code will crash without any option to handle the error.
-    /// For safe `Regex` initialization, use the `init(_: String, options: Options) throws` overload instead.
-    ///
-    /// - parameter stringLiteral: The pattern string.
-    public init(stringLiteral value: String) {
-        do {
-            try self.init(value)
-        } catch {
-            preconditionFailure("Not a valid regex: \(value)")
-        }
-    }
-}
-
 // MARK: - CustomStringConvertible
 extension Regex: CustomStringConvertible {
     /// Returns a string describing the regex using its pattern string.

--- a/Frameworks/HandySwift/Structs/Regex.swift
+++ b/Frameworks/HandySwift/Structs/Regex.swift
@@ -122,9 +122,9 @@ extension Regex: Equatable {
 
 // MARK: - Hashable
 extension Regex: Hashable {
-    /// Returns a unique hash value for the `Regex` instance.
-    public var hashValue: Int {
-        return regularExpression.hashValue
+    /// Manages hashing of the `Regex` instance.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(regularExpression)
     }
 }
 


### PR DESCRIPTION
This PR removes the already deprecated `ExpressibleByStringLiteral` conformance of the `Regex` type to only allow initialization via the `init(_:options:) throws` interface.

In Xcode 10.2, even when not yet migrated to Swift 5, the following code will be interpreted as using the `ExpressibleByStringLiteral` initializer:

```
let regex = Regex("abc")
```

While this initializer was originally introduced to allow for such inits as `let regex: regex = "abc"`, the validity of the code above isn't necessarily bad. However, it leads to confusion with the suggested `init(_:options:=[]) throws` initializer, so that warnings about the initializer not throwing will appear for such valid code as this:

```
let regex = try? Regex("abc")
```

Clearly, this is a very bad confusion of available initializers, not only because there are "wrong" warnings, but also because an unintended initializer is used. This is why I suggest dropping the `ExpressibleByStringLiteral` initializer. It's already deprecated for a while and was only part of the official documentation for a few days, so it's probably not in common use.