### PR TITLE
Implement generic average

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 ### Added
-- None.
+- New `DivisibleArithmetic` protocol which easily extends `average()` to Collections of `Double`, `Float` and `CGFloat`.
 ### Changed
 - None.
 ### Deprecated

--- a/HandySwift.xcodeproj/project.pbxproj
+++ b/HandySwift.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		3F95C8D520F22DEE0045AFD0 /* CollectionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95C8D320F22DC60045AFD0 /* CollectionExtensionTests.swift */; };
 		3F95C8D620F22DEF0045AFD0 /* CollectionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95C8D320F22DC60045AFD0 /* CollectionExtensionTests.swift */; };
 		3F95C8D720F22DEF0045AFD0 /* CollectionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95C8D320F22DC60045AFD0 /* CollectionExtensionTests.swift */; };
+		63651F90231BFF2000E022DA /* DivisibleArithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63651F8F231BFF2000E022DA /* DivisibleArithmetic.swift */; };
+		63651F91231BFF2000E022DA /* DivisibleArithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63651F8F231BFF2000E022DA /* DivisibleArithmetic.swift */; };
+		63651F92231BFF2800E022DA /* DivisibleArithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63651F8F231BFF2000E022DA /* DivisibleArithmetic.swift */; };
 		8218E4D62211D193007AAAF3 /* NSRangeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8218E4D52211D193007AAAF3 /* NSRangeExtension.swift */; };
 		8218E4D72211D193007AAAF3 /* NSRangeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8218E4D52211D193007AAAF3 /* NSRangeExtension.swift */; };
 		8218E4D82211D193007AAAF3 /* NSRangeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8218E4D52211D193007AAAF3 /* NSRangeExtension.swift */; };
@@ -133,6 +136,7 @@
 		2E4189DB231B971E00C65B81 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		3F95C8D120F22A3C0045AFD0 /* CollectionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtension.swift; sourceTree = "<group>"; };
 		3F95C8D320F22DC60045AFD0 /* CollectionExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtensionTests.swift; sourceTree = "<group>"; };
+		63651F8F231BFF2000E022DA /* DivisibleArithmetic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisibleArithmetic.swift; sourceTree = "<group>"; };
 		8218E4D52211D193007AAAF3 /* NSRangeExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRangeExtension.swift; sourceTree = "<group>"; };
 		8218E4D92211D270007AAAF3 /* NSRangeExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRangeExtensionTests.swift; sourceTree = "<group>"; };
 		8218E4DD2211D7D3007AAAF3 /* CODE_OF_CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CODE_OF_CONDUCT.md; sourceTree = "<group>"; };
@@ -311,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				8251AA1F22786D460022B277 /* Withable.swift */,
+				63651F8F231BFF2000E022DA /* DivisibleArithmetic.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -706,6 +711,7 @@
 				82CAE2961C2EE64900F934A7 /* ArrayExtension.swift in Sources */,
 				C5CFB6AC20B0A70300830511 /* Unowned.swift in Sources */,
 				82812A9B1D06877B00CD5B6C /* Globals.swift in Sources */,
+				63651F90231BFF2000E022DA /* DivisibleArithmetic.swift in Sources */,
 				8280D7DC1C4A6EC9001172EF /* DictionaryExtension.swift in Sources */,
 				A11830D31E589F6700CBE087 /* TimeIntervalExtension.swift in Sources */,
 			);
@@ -750,6 +756,7 @@
 				825EFE021C33358400558497 /* SortedArray.swift in Sources */,
 				825EFE031C33358400558497 /* IntExtension.swift in Sources */,
 				82812A9C1D06877B00CD5B6C /* Globals.swift in Sources */,
+				63651F91231BFF2000E022DA /* DivisibleArithmetic.swift in Sources */,
 				8280D7DD1C4A6EC9001172EF /* DictionaryExtension.swift in Sources */,
 				A11830D41E589F6700CBE087 /* TimeIntervalExtension.swift in Sources */,
 			);
@@ -794,6 +801,7 @@
 				825EFE081C33358500558497 /* SortedArray.swift in Sources */,
 				825EFE091C33358500558497 /* IntExtension.swift in Sources */,
 				82812A9D1D06877B00CD5B6C /* Globals.swift in Sources */,
+				63651F92231BFF2800E022DA /* DivisibleArithmetic.swift in Sources */,
 				8280D7DE1C4A6EC9001172EF /* DictionaryExtension.swift in Sources */,
 				A11830D51E589F6700CBE087 /* TimeIntervalExtension.swift in Sources */,
 			);

--- a/Sources/HandySwift/Extensions/CollectionExtension.swift
+++ b/Sources/HandySwift/Extensions/CollectionExtension.swift
@@ -19,16 +19,16 @@ extension Sequence where Element: Numeric {
     }
 }
 
-extension Collection where Element == Int {
-    /// Returns the average of all elements as a Double value.
-    public func average() -> Double {
-        return reduce(0) { $0 + Double($1) } / Double(count)
+extension Collection where Element: DivisibleArithmetic {
+    /// Returns the average of all elements.
+    public func average() -> Element {
+        return reduce(.zero, +) / Element(count)
     }
 }
 
-extension Collection where Element == Double {
+extension Collection where Element == Int {
     /// Returns the average of all elements as a Double value.
-    public func average() -> Double {
-        return reduce(0, +) / Double(count)
+    public func average<ReturnType: DivisibleArithmetic>() -> ReturnType {
+        return ReturnType(reduce(0, +)) / ReturnType(count)
     }
 }

--- a/Sources/HandySwift/Extensions/CollectionExtension.swift
+++ b/Sources/HandySwift/Extensions/CollectionExtension.swift
@@ -22,13 +22,13 @@ extension Sequence where Element: Numeric {
 extension Collection where Element: DivisibleArithmetic {
     /// Returns the average of all elements.
     public func average() -> Element {
-        return reduce(.zero, +) / Element(count)
+        return sum() / Element(count)
     }
 }
 
 extension Collection where Element == Int {
     /// Returns the average of all elements as a Double value.
     public func average<ReturnType: DivisibleArithmetic>() -> ReturnType {
-        return ReturnType(reduce(0, +)) / ReturnType(count)
+        return ReturnType(sum()) / ReturnType(count)
     }
 }

--- a/Sources/HandySwift/Protocols/DivisibleArithmetic.swift
+++ b/Sources/HandySwift/Protocols/DivisibleArithmetic.swift
@@ -1,0 +1,13 @@
+// Copyright © 2019 Flinesoft. All rights reserved.
+
+import CoreGraphics
+
+/// A type which conforms to DivisibleArithmetic provides the basic arithmetic operations: additon, subtraction, multiplication and division.
+public protocol DivisibleArithmetic: Numeric {
+    init(_ value: Int)
+    static func /(lhs: Self, rhs: Self) -> Self
+}
+
+extension Double: DivisibleArithmetic {}
+extension Float: DivisibleArithmetic {}
+extension CGFloat: DivisibleArithmetic {}

--- a/Tests/HandySwiftTests/Extensions/CollectionExtensionTests.swift
+++ b/Tests/HandySwiftTests/Extensions/CollectionExtensionTests.swift
@@ -28,7 +28,13 @@ class CollectionExtensionTests: XCTestCase {
         let intArray = [1, 2, 10]
         XCTAssertEqual(intArray.average(), 4.333, accuracy: 0.001)
 
+        let averageAsCGFloat: CGFloat = intArray.average()
+        XCTAssertEqual(averageAsCGFloat, 4.333, accuracy: 0.001)
+
         let doubleArray = [1.0, 2.0, 10.0]
         XCTAssertEqual(doubleArray.average(), 4.333, accuracy: 0.001)
+
+        let cgFloatArray: [CGFloat] = [1.0, 2.0, 10.0]
+        XCTAssertEqual(cgFloatArray.average(), 4.333, accuracy: 0.001)
     }
 }

--- a/UsageExamples.playground/Contents.swift
+++ b/UsageExamples.playground/Contents.swift
@@ -128,10 +128,12 @@ arrayForTry[try: 20]
 [0.5, 1.5, 2.5].sum()
 
 //: ### .average()
-//: Returns the average of all elements as a Double value.
-//: NOTE: Only available for `Int` and `Double` collections.
+//: Returns the average of all elements.
+//: NOTE: For `Int` collections, the average is returned alternatively as a `Double`, `Float` or `CGFloat` value.
 [10, 20, 30, 40].average()
 [10.75, 20.75, 30.25, 40.25].average()
+let averageAsFloat: Float = [10, 20, 30, 40].average()
+averageAsFloat
 
 //: ## DictionaryExtension
 //: ### init?(keys:values:)


### PR DESCRIPTION
Implements #36. Adds a simple protocol `DivisibleArithmetic` (matching the Swift-style of [AdditiveArithmetic](https://developer.apple.com/documentation/swift/additivearithmetic) and [Numeric](https://developer.apple.com/documentation/swift/numeric)). `Double`, `Float` and `CGFloat` conform to `DivisibleArithmetic`, allowing to take averages from Arrays of all three types.

Additionally, when calculating the `average()` of an `Int` Array, you can choose the return type to be anything complying with `DivisibleArithmetic` (not just Double as before).