### PR TITLE
Make most of the API `@inlinable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 ### Added
 - New `DivisibleArithmetic` protocol which easily extends `average()` to Collections of `Double`, `Float` and `CGFloat`.
+- Make most of the API `@inlinable` for increased real-time performance.
 ### Changed
 - None.
 ### Deprecated

--- a/Sources/HandySwift/Extensions/ArrayExt.swift
+++ b/Sources/HandySwift/Extensions/ArrayExt.swift
@@ -13,6 +13,7 @@ extension Array {
     /// - Parameters:
     ///   - other: Other array to combine the elements with.
     /// - Returns: An array of tuples with the elements of both arrays combined.
+    @inlinable
     public func combinations<T>(with other: [T]) -> [Combination<T>] {
         var combinations = [(Element, T)]()
         forEach { elem in other.forEach { otherElem in combinations.append((elem, otherElem)) } }
@@ -27,6 +28,7 @@ extension Array {
     /// - Parameters:
     ///   - stable: Speifies if the sorting algorithm should be stable.
     ///   - areInIncreasingOrder: The closure to specify the order of the elements to be sorted by.
+    @inlinable
     public mutating func sort(by areInIncreasingOrder: @escaping (Element, Element) -> Bool, stable: Bool) {
         guard stable else { sort(by: areInIncreasingOrder); return }
         stableMergeSort(by: areInIncreasingOrder)
@@ -39,6 +41,7 @@ extension Array {
     /// - Parameters:
     ///   - stable: Speifies if the sorting algorithm should be stable.
     ///   - areInIncreasingOrder: The closure to specify the order of the elements to be sorted by.
+    @inlinable
     public func sorted(by areInIncreasingOrder: @escaping (Element, Element) -> Bool, stable: Bool) -> [Element] {
         guard stable else { return sorted(by: areInIncreasingOrder) }
 
@@ -49,6 +52,7 @@ extension Array {
     }
 
     /// Sorts the array in-place using a stable merge sort algorithm.
+    @inlinable
     mutating func stableMergeSort(by areInIncreasingOrder: @escaping (Element, Element) -> Bool) {
         var tmp = [Element]()
         tmp.reserveCapacity(numericCast(count))
@@ -91,7 +95,7 @@ extension RandomAccessCollection where Index == Int {
     /// Returns a random element from the `Array`.
     ///
     /// - Returns: A random element from the array or `nil` if empty.
-    public var sample: Element? {
+    @inlinable public var sample: Element? {
         guard let randomIndex = Int(randomBelow: count) else { return nil }
         return self[randomIndex]
     }
@@ -101,6 +105,7 @@ extension RandomAccessCollection where Index == Int {
     /// - Parameters:
     ///   - size: The number of random elements wanted.
     /// - Returns: An array with the given number of random elements or `nil` if empty.
+    @inlinable
     public func sample(size: Int) -> [Element]? {
         guard !isEmpty else { return nil }
 
@@ -118,6 +123,7 @@ extension Array where Element: Comparable {
     ///
     /// - Parameters:
     ///   - stable: Speifies if the sorting algorithm should be stable.
+    @inlinable
     public mutating func sort(stable: Bool) {
         sort(by: { lhs, rhs in  lhs < rhs }, stable: stable)
     }
@@ -128,6 +134,7 @@ extension Array where Element: Comparable {
     ///
     /// - Parameters:
     ///   - stable: Speifies if the sorting algorithm should be stable.
+    @inlinable
     public func sorted(stable: Bool) -> [Element] {
         sorted(by: { lhs, rhs in lhs < rhs }, stable: stable)
     }

--- a/Sources/HandySwift/Extensions/CollectionExt.swift
+++ b/Sources/HandySwift/Extensions/CollectionExt.swift
@@ -7,6 +7,7 @@ extension Collection {
     ///
     /// - Parameters:
     ///   - try: The index of the element.
+    @inlinable
     public subscript(try index: Index) -> Element? {
         indices.contains(index) ? self[index] : nil
     }
@@ -14,6 +15,7 @@ extension Collection {
 
 extension Sequence where Element: Numeric {
     /// Returns the sum of all elements.
+    @inlinable
     public func sum() -> Element {
         reduce(0, +)
     }
@@ -21,6 +23,7 @@ extension Sequence where Element: Numeric {
 
 extension Collection where Element: DivisibleArithmetic {
     /// Returns the average of all elements.
+    @inlinable
     public func average() -> Element {
         sum() / Element(count)
     }
@@ -28,6 +31,7 @@ extension Collection where Element: DivisibleArithmetic {
 
 extension Collection where Element == Int {
     /// Returns the average of all elements as a Double value.
+    @inlinable
     public func average<ReturnType: DivisibleArithmetic>() -> ReturnType {
         ReturnType(sum()) / ReturnType(count)
     }

--- a/Sources/HandySwift/Extensions/ComparableExt.swift
+++ b/Sources/HandySwift/Extensions/ComparableExt.swift
@@ -11,6 +11,7 @@ extension Comparable {
     ///     - `self`, if it is inside the given limits.
     ///     - `lowerBound` of the given limits, if `self` is smaller than it.
     ///     - `upperBound` of the given limits, if `self` is greater than it.
+    @inlinable
     public func clamped(to limits: ClosedRange<Self>) -> Self {
         if limits.lowerBound > self {
             return limits.lowerBound
@@ -27,6 +28,7 @@ extension Comparable {
     /// - Returns:
     ///     - `self`, if it is inside the given limits.
     ///     - `lowerBound` of the given limits, if `self` is smaller than it.
+    @inlinable
     public func clamped(to limits: PartialRangeFrom<Self>) -> Self {
         if limits.lowerBound > self {
             return limits.lowerBound
@@ -41,6 +43,7 @@ extension Comparable {
     /// - Returns:
     ///     - `self`, if it is inside the given limits.
     ///     - `upperBound` of the given limits, if `self` is greater than it.
+    @inlinable
     public func clamped(to limits: PartialRangeThrough<Self>) -> Self {
         if limits.upperBound < self {
             return limits.upperBound
@@ -57,6 +60,7 @@ extension Comparable {
     /// - `upperBound` of the given limits, if `self` is greater than it.
     ///
     /// - Parameter limits: The closed range determining minimum & maxmimum value.
+    @inlinable
     public mutating func clamp(to limits: ClosedRange<Self>) {
         self = clamped(to: limits)
     }
@@ -67,6 +71,7 @@ extension Comparable {
     /// - `lowerBound` of the given limits, if `self` is smaller than it.
     ///
     /// - Parameter limits: The partial range (from) determining the minimum value.
+    @inlinable
     public mutating func clamp(to limits: PartialRangeFrom<Self>) {
         self = clamped(to: limits)
     }
@@ -77,6 +82,7 @@ extension Comparable {
     /// - `upperBound` of the given limits, if `self` is greater than it.
     ///
     /// - Parameter limits: The partial range (through) determining the maximum value.
+    @inlinable
     public mutating func clamp(to limits: PartialRangeThrough<Self>) {
         self = clamped(to: limits)
     }

--- a/Sources/HandySwift/Extensions/DictionaryExt.swift
+++ b/Sources/HandySwift/Extensions/DictionaryExt.swift
@@ -8,6 +8,7 @@ extension Dictionary {
     /// - Parameters:
     ///   - keys:       The `Array` of keys.
     ///   - values:     The `Array` of values.
+    @inlinable
     public init?(keys: [Key], values: [Value]) {
         guard keys.count == values.count else { return nil }
         self.init()
@@ -18,6 +19,7 @@ extension Dictionary {
     ///
     /// - Parameters:
     ///   - otherDictionary:    The other `Dictionary` to merge into this `Dictionary`.
+    @inlinable
     public mutating func merge(_ other: [Key: Value]) {
         for (key, value) in other { self[key] = value }
     }
@@ -28,6 +30,7 @@ extension Dictionary {
     /// - Parameters:
     ///   - otherDictionary:    The other `Dictionary` to merge into this `Dictionary`.
     /// - Returns: The new Dictionary with merged keys and values from this and the other `Dictionary`.
+    @inlinable
     public func merged(with other: [Key: Value]) -> [Key: Value] {
         var newDict: [Key: Value] = [:]
         [self, other].forEach { dict in for (key, value) in dict { newDict[key] = value } }

--- a/Sources/HandySwift/Extensions/IntExt.swift
+++ b/Sources/HandySwift/Extensions/IntExt.swift
@@ -16,6 +16,7 @@ extension Int {
     ///
     /// - Parameters:
     ///   - closure: The code to be run multiple times.
+    @inlinable
     public func times(_ closure: () -> Void) {
         guard self > 0 else { return }
         for _ in 0 ..< self { closure() }
@@ -26,6 +27,7 @@ extension Int {
     ///
     /// - Parameters:
     ///   - closure: The code to deliver a return value multiple times.
+    @inlinable
     public func timesMake<ReturnType>(_ closure: () -> ReturnType) -> [ReturnType] {
         guard self > 0 else { return [] }
         return (0 ..< self).map { _ in closure() }

--- a/Sources/HandySwift/Extensions/StringExt.swift
+++ b/Sources/HandySwift/Extensions/StringExt.swift
@@ -56,6 +56,7 @@ extension String {
     /// - Parameters:
     ///   - size: The number of random characters wanted.
     /// - Returns: A String with the given number of random characters or `nil` if empty.
+    @inlinable
     public func sample(size: Int) -> String? {
         guard !isEmpty else { return nil }
 

--- a/Sources/HandySwift/Extensions/TimeIntervalExt.swift
+++ b/Sources/HandySwift/Extensions/TimeIntervalExt.swift
@@ -7,81 +7,88 @@ public typealias Timespan = TimeInterval
 
 extension TimeInterval {
     // MARK: - Computed Type Properties
-    internal static var secondsPerDay: Double { 24 * 60 * 60 }
-    internal static var secondsPerHour: Double { 60 * 60 }
-    internal static var secondsPerMinute: Double { 60 }
-    internal static var millisecondsPerSecond: Double { 1_000 }
-    internal static var microsecondsPerSecond: Double { 1_000 * 1_000 }
-    internal static var nanosecondsPerSecond: Double { 1_000 * 1_000 * 1_000 }
+    @usableFromInline internal static var secondsPerDay: Double { 24 * 60 * 60 }
+    @usableFromInline internal static var secondsPerHour: Double { 60 * 60 }
+    @usableFromInline internal static var secondsPerMinute: Double { 60 }
+    @usableFromInline internal static var millisecondsPerSecond: Double { 1_000 }
+    @usableFromInline internal static var microsecondsPerSecond: Double { 1_000 * 1_000 }
+    @usableFromInline internal static var nanosecondsPerSecond: Double { 1_000 * 1_000 * 1_000 }
 
     // MARK: - Computed Instance Properties
     /// - Returns: The `TimeInterval` in days.
-    public var days: Double {
+    @inlinable public var days: Double {
         self / TimeInterval.secondsPerDay
     }
 
     /// - Returns: The `TimeInterval` in hours.
-    public var hours: Double {
+    @inlinable public var hours: Double {
         self / TimeInterval.secondsPerHour
     }
 
     /// - Returns: The `TimeInterval` in minutes.
-    public var minutes: Double {
+    @inlinable public var minutes: Double {
         self / TimeInterval.secondsPerMinute
     }
 
     /// - Returns: The `TimeInterval` in seconds.
-    public var seconds: Double {
+    @inlinable public var seconds: Double {
         self
     }
 
     /// - Returns: The `TimeInterval` in milliseconds.
-    public var milliseconds: Double {
+    @inlinable public var milliseconds: Double {
         self * TimeInterval.millisecondsPerSecond
     }
 
     /// - Returns: The `TimeInterval` in microseconds.
-    public var microseconds: Double {
+    @inlinable public var microseconds: Double {
         self * TimeInterval.microsecondsPerSecond
     }
 
     /// - Returns: The `TimeInterval` in nanoseconds.
-    public var nanoseconds: Double {
+    @inlinable public var nanoseconds: Double {
         self * TimeInterval.nanosecondsPerSecond
     }
 
     // MARK: - Type Methods
     /// - Returns: The time in days using the `TimeInterval` type.
+    @inlinable
     public static func days(_ value: Double) -> TimeInterval {
         value * secondsPerDay
     }
 
     /// - Returns: The time in hours using the `TimeInterval` type.
+    @inlinable
     public static func hours(_ value: Double) -> TimeInterval {
         value * secondsPerHour
     }
 
     /// - Returns: The time in minutes using the `TimeInterval` type.
+    @inlinable
     public static func minutes(_ value: Double) -> TimeInterval {
         value * secondsPerMinute
     }
 
     /// - Returns: The time in seconds using the `TimeInterval` type.
+    @inlinable
     public static func seconds(_ value: Double) -> TimeInterval {
         value
     }
 
     /// - Returns: The time in milliseconds using the `TimeInterval` type.
+    @inlinable
     public static func milliseconds(_ value: Double) -> TimeInterval {
         value / millisecondsPerSecond
     }
 
     /// - Returns: The time in microseconds using the `TimeInterval` type.
+    @inlinable
     public static func microseconds(_ value: Double) -> TimeInterval {
         value / microsecondsPerSecond
     }
 
     /// - Returns: The time in nanoseconds using the `TimeInterval` type.
+    @inlinable
     public static func nanoseconds(_ value: Double) -> TimeInterval {
         value / nanosecondsPerSecond
     }

--- a/Sources/HandySwift/Protocols/Withable.swift
+++ b/Sources/HandySwift/Protocols/Withable.swift
@@ -8,12 +8,14 @@ public protocol Withable {
 
 extension Withable {
     /// Construct a new instance, setting an arbitrary subset of properties.
+    @inlinable
     public init(with config: (inout Self) -> Void) {
         self.init()
         config(&self)
     }
 
     /// Create a copy, overriding an arbitrary subset of properties.
+    @inlinable
     public func with(_ config: (inout Self) -> Void) -> Self {
         var copy = self
         config(&copy)

--- a/Sources/HandySwift/Structs/FrequencyTable.swift
+++ b/Sources/HandySwift/Structs/FrequencyTable.swift
@@ -5,17 +5,18 @@ import Foundation
 /// Data structure to retrieve random values with their frequency taken into account.
 public struct FrequencyTable<T> {
     // MARK: - Sub Types
+    @usableFromInline
     typealias Entry = (value: T, frequency: Int)
 
     // MARK: - Stored Instance Properties
-    private let valuesWithFrequencies: [Entry]
+    @usableFromInline internal let valuesWithFrequencies: [Entry]
 
     /// Contains all values the amount of time of their frequencies.
-    private let frequentValues: [T]
+    @usableFromInline internal let frequentValues: [T]
 
     // MARK: - Computed Instance Properties
     /// - Returns: A random value taking frequencies into account or nil if values empty.
-    public var sample: T? { frequentValues.sample }
+    @inlinable public var sample: T? { frequentValues.sample }
 
     // MARK: - Initializers
     /// Creates a new FrequencyTable instance with values and their frequencies provided.
@@ -23,6 +24,7 @@ public struct FrequencyTable<T> {
     /// - Parameters:
     ///   - values: An array full of values to be saved into the frequency table.
     ///   - frequencyClosure: The closure to specify the frequency for a specific value.
+    @inlinable
     public init(values: [T], frequencyClosure: (T) -> Int) {
         valuesWithFrequencies = values.map { ($0, frequencyClosure($0)) }
         frequentValues = valuesWithFrequencies.reduce(into: []) { memo, entry in
@@ -37,6 +39,7 @@ public struct FrequencyTable<T> {
     ///     - size: The size of the resulting array of random values.
     ///
     /// - Returns: An array of random values or nil if values empty.
+    @inlinable
     public func sample(size: Int) -> [T]? {
         guard size > 0 && !frequentValues.isEmpty else { return nil }
         return Array(0 ..< size).map { _ in sample! }

--- a/Sources/HandySwift/Structs/Regex.swift
+++ b/Sources/HandySwift/Structs/Regex.swift
@@ -6,7 +6,7 @@ import Foundation
 /// `Regex` is a swifty regex engine built on top of the NSRegularExpression api.
 public struct Regex {
     // MARK: - Properties
-    private let regularExpression: NSRegularExpression
+    @usableFromInline internal let regularExpression: NSRegularExpression
 
     // MARK: - Initializers
     /// Create a `Regex` based on a pattern string.
@@ -33,6 +33,7 @@ public struct Regex {
     /// - parameter string: The string to test.
     ///
     /// - returns: `true` if the regular expression matches, otherwise `false`.
+    @inlinable
     public func matches(_ string: String) -> Bool {
         firstMatch(in: string) != nil
     }
@@ -44,6 +45,7 @@ public struct Regex {
     /// - parameter string: The string to match against.
     ///
     /// - returns: An optional `Match` describing the first match, or `nil`.
+    @inlinable
     public func firstMatch(in string: String) -> Match? {
         let firstMatch = regularExpression
             .firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count))
@@ -58,6 +60,7 @@ public struct Regex {
     /// - parameter string: The string to match against.
     ///
     /// - returns: An array of `Match` describing every match in `string`.
+    @inlinable
     public func matches(in string: String) -> [Match] {
         let matches = regularExpression
             .matches(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count))
@@ -82,6 +85,7 @@ public struct Regex {
     ///     - count: The maximum count of matches to replace, beginning with the first match.
     ///
     /// - returns: A string with all matches of `regex` replaced by `template`.
+    @inlinable
     public func replacingMatches(in input: String, with template: String, count: Int? = nil) -> String {
         var output = input
         let matches = self.matches(in: input)
@@ -219,6 +223,7 @@ extension Regex {
         private let baseString: String
 
         // MARK: - Initializers
+        @usableFromInline
         internal init(result: NSTextCheckingResult, in string: String) {
             precondition(
                 result.regularExpression != nil,

--- a/Sources/HandySwift/Structs/SortedArray.swift
+++ b/Sources/HandySwift/Structs/SortedArray.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Data structure to keep a sorted array of elements for fast access.
 public struct SortedArray<Element: Comparable> {
     // MARK: - Stored Instance Properties
-    private var internalArray: [Element]
+    @usableFromInline internal var internalArray: [Element]
 
     /// Returns the sorted array of elements.
     public var array: [Element] { self.internalArray }
@@ -30,7 +30,8 @@ public struct SortedArray<Element: Comparable> {
         self.init(sequence: sequence, preSorted: false)
     }
 
-    private init<S: Sequence>(sequence: S, preSorted: Bool) where S.Iterator.Element == Element {
+    @usableFromInline
+    internal init<S: Sequence>(sequence: S, preSorted: Bool) where S.Iterator.Element == Element {
         internalArray = preSorted ? Array(sequence) : Array(sequence).sorted()
     }
 
@@ -43,6 +44,7 @@ public struct SortedArray<Element: Comparable> {
     /// - Parameters:
     ///   - predicate: The predicate to match the elements against.
     /// - Returns: The index of the first matching element or `nil` if none of them matches.
+    @inlinable
     public func index(where predicate: (Element) -> Bool) -> Int? {
         // cover trivial cases
         guard !array.isEmpty else { return nil }
@@ -75,6 +77,7 @@ public struct SortedArray<Element: Comparable> {
     /// - Parameters:
     ///   - index: The upper bound index until which to include elements.
     /// - Returns: A new SortedArray instance including all elements until the specified index (exluding it).
+    @inlinable
     public func prefix(upTo index: Int) -> SortedArray {
         let subarray = Array(array[array.indices.prefix(upTo: index)])
         return SortedArray(sequence: subarray, preSorted: true)
@@ -87,6 +90,7 @@ public struct SortedArray<Element: Comparable> {
     /// - Parameters:
     ///   - index: The upper bound index until which to include elements.
     /// - Returns: A new SortedArray instance including all elements until the specified index (including it).
+    @inlinable
     public func prefix(through index: Int) -> SortedArray {
         let subarray = Array(array[array.indices.prefix(through: index)])
         return SortedArray(sequence: subarray, preSorted: true)
@@ -99,6 +103,7 @@ public struct SortedArray<Element: Comparable> {
     /// - Parameters:
     ///   - index: The lower bound index from which to start including elements.
     /// - Returns: A new SortedArray instance including all elements starting at the specified index.
+    @inlinable
     public func suffix(from index: Int) -> SortedArray {
         let subarray = Array(array[array.indices.suffix(from: index)])
         return SortedArray(sequence: subarray, preSorted: true)
@@ -111,6 +116,7 @@ public struct SortedArray<Element: Comparable> {
     ///
     /// - Parameters:
     ///   - newElement: The new element to be inserted into the array.
+    @inlinable
     public mutating func insert(newElement: Element) {
         let insertIndex = internalArray.firstIndex { $0 >= newElement } ?? internalArray.endIndex
         internalArray.insert(newElement, at: insertIndex)
@@ -122,6 +128,7 @@ public struct SortedArray<Element: Comparable> {
     ///
     /// - Parameters:
     ///   - sequence
+    @inlinable
     public mutating func insert<S: Sequence>(contentsOf sequence: S) where S.Iterator.Element == Element {
         sequence.forEach { insert(newElement: $0) }
     }
@@ -132,6 +139,7 @@ public struct SortedArray<Element: Comparable> {
     ///
     /// - Parameters:
     ///   - index: The index of the element to remove from the sorted array.
+    @inlinable
     public mutating func remove(at index: Int) {
         internalArray.remove(at: index)
     }
@@ -140,6 +148,7 @@ public struct SortedArray<Element: Comparable> {
     ///
     /// - Parameter
     ///   - bounds: A range of the SortedArray's indices. The bounds of the range must be valid indices.
+    @inlinable
     public subscript(bounds: Range<Int>) -> SortedArray {
         SortedArray(sequence: array[bounds], preSorted: true)
     }
@@ -148,22 +157,25 @@ public struct SortedArray<Element: Comparable> {
 extension SortedArray: Collection {
     public typealias Index = Array<Element>.Index
 
-    public var startIndex: Int {
+    @inlinable public var startIndex: Int {
         internalArray.startIndex
     }
 
-    public var endIndex: Int {
+    @inlinable public var endIndex: Int {
         internalArray.endIndex
     }
 
+    @inlinable
     public func sorted() -> [Element] {
         internalArray
     }
 
+    @inlinable
     public func index(after index: Int) -> Int {
         internalArray.index(after: index)
     }
 
+    @inlinable
     public subscript(position: Int) -> Element {
         internalArray[position]
     }

--- a/Sources/HandySwift/Structs/Weak.swift
+++ b/Sources/HandySwift/Structs/Weak.swift
@@ -24,6 +24,7 @@ public struct Weak<Wrapped>: ExpressibleByNilLiteral where Wrapped: AnyObject {
     ///   of the instance.
     /// - Returns: The result of the given closure. If this instance is `nil`,
     ///   returns `nil`.
+    @inlinable
     public func map<U>(_ transform: (Wrapped) throws -> U) rethrows -> U? {
         guard let value = value else { return nil }
 
@@ -37,6 +38,7 @@ public struct Weak<Wrapped>: ExpressibleByNilLiteral where Wrapped: AnyObject {
     ///   of the instance.
     /// - Returns: The result of the given closure. If this instance is `nil`,
     ///   returns `nil`.
+    @inlinable
     public func flatMap<U>(_ transform: (Wrapped) throws -> U?) rethrows -> U? {
         guard let value = value else { return nil }
 


### PR DESCRIPTION
This implements #40 by marking sensible methods (i.e. any methods where inlining may yield a performance improvement), subscripts and property getters as `@inlinable`. This is, in fact, most of the HandySwift API.