### PR TITLE
Add custom `RandomNumberGenerator` source to `Int.init?(randomBelow:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 - New `DivisibleArithmetic` protocol which easily extends `average()` to Collections of `Double`, `Float` and `CGFloat`.
 ### Changed
-- None.
+- Allow `Int.init?(randomBelow:)` to use an arbitrary RandomNumberGenerator (instead of just the system one).
 ### Deprecated
 - None.
 ### Removed

--- a/Sources/HandySwift/Extensions/IntExt.swift
+++ b/Sources/HandySwift/Extensions/IntExt.swift
@@ -12,6 +12,16 @@ extension Int {
         self = .random(in: 0 ..< upperLimit)
     }
 
+    /// Initializes a new `Int ` instance with a random value below a given `Int`.
+    ///
+    /// - Parameters:
+    ///   - randomBelow: The upper bound value to create a random value with.
+    ///   - generator: The `RandomNumberGenerator` source that should be used to generate random numbers.
+    public init?<Generator: RandomNumberGenerator>(randomBelow upperLimit: Int, using generator: inout Generator) {
+        guard upperLimit > 0 else { return nil }
+        self = .random(in: 0 ..< upperLimit, using: &generator)
+    }
+
     /// Runs the code passed as a closure the specified number of times.
     ///
     /// - Parameters:

--- a/Tests/HandySwiftTests/Extensions/IntExtensionTests.swift
+++ b/Tests/HandySwiftTests/Extensions/IntExtensionTests.swift
@@ -11,6 +11,14 @@ class IntExtensionTests: XCTestCase {
             XCTAssertNil(Int(randomBelow: 0))
             XCTAssertNil(Int(randomBelow: -1))
         }
+
+        var generator = SystemRandomNumberGenerator()
+        10.times {
+            XCTAssertTrue(Int(randomBelow: 15, using: &generator)! < 15)
+            XCTAssertTrue(Int(randomBelow: 15, using: &generator)! >= 0)
+            XCTAssertNil(Int(randomBelow: 0, using: &generator))
+            XCTAssertNil(Int(randomBelow: -1, using: &generator))
+        }
     }
 
     func testTimesMethod() {


### PR DESCRIPTION
This allows users to provide the RNG of their choice for creating pseudo-random integers.

I.e., instead of
```
let values = 100.timesMake { Int(randomBelow: 10) }
```
users could write:
```
var xoshiro = Xoshiro() // Some third-party RNG
let values = 100.timesMake { Int(randomBelow: 10, using: &xoshiro) }
```