### PR TITLE
Remove init requirement & syntax sugar from Withable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,111 @@
+name: CI
+
+on:
+  push:
+    branches: [main, versions]
+
+  pull_request:
+    branches: [main]
+
+jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel previous runs of this workflow on same branch
+        uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  anylint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Export latest tool versions
+        run: |
+          latest_version() {
+            curl --silent "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+          }
+          echo "::set-env name=ANYLINT_LATEST_VERSION::$( latest_version Flinesoft/AnyLint )"
+          echo "::set-env name=SWIFT_SH_LATEST_VERSION::$( latest_version mxcl/swift-sh )"
+
+      - name: AnyLint Cache
+        uses: actions/cache@v1
+        id: anylint-cache
+        with:
+          path: anylint-cache
+          key: ${{ runner.os }}-v1-anylint-${{ env.ANYLINT_LATEST_VERSION }}-swift-sh-${{ env.SWIFT_SH_LATEST_VERSION }}
+
+      - name: Copy from cache
+        if: steps.anylint-cache.outputs.cache-hit
+        run: |
+          sudo cp -f anylint-cache/anylint /usr/local/bin/anylint
+          sudo cp -f anylint-cache/swift-sh /usr/local/bin/swift-sh
+
+      - name: Install AnyLint
+        if: steps.anylint-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/Flinesoft/AnyLint.git
+          cd AnyLint
+          swift build -c release
+          sudo cp -f .build/release/anylint /usr/local/bin/anylint
+
+      - name: Install swift-sh
+        if: steps.anylint-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/mxcl/swift-sh.git
+          cd swift-sh
+          swift build -c release
+          sudo cp -f .build/release/swift-sh /usr/local/bin/swift-sh
+
+      - name: Copy to cache
+        if: steps.anylint-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p anylint-cache
+          cp -f /usr/local/bin/anylint anylint-cache/anylint
+          cp -f /usr/local/bin/swift-sh anylint-cache/swift-sh
+
+      - name: Cleanup checkouts
+        run: rm -rf AnyLint && rm -rf swift-sh
+
+      - name: Run AnyLint
+        run: anylint
+
+  swiftlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run SwiftLint
+        uses: norio-nomura/action-swiftlint@3.1.0
+        with:
+          args: --strict
+
+  test-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: swift test -v
+
+  test-macos:
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: swift test -v --enable-code-coverage
+
+      - name: Report Code Coverage
+        run: |
+          xcrun llvm-cov export -format="lcov" .build/debug/${PACKAGE_NAME}PackageTests.xctest/Contents/MacOS/${PACKAGE_NAME}PackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.lcov
+        env:
+          PACKAGE_NAME: HandySwift
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Added
 - None.
 ### Changed
-- None.
+- `Withable` doesn't require an empty `init()` method anymore. Instead, it can be combined with any initializer. If you used the `Foo { $0.bar = 5 }` type of initializer, you will need to add `().with` behind the type like so: `Foo().with { $0.bar = 5 }`.  
+  Issue: [#49](https://github.com/Flinesoft/HandySwift/issues/49) | PR: [#50](https://github.com/Flinesoft/HandySwift/pull/50) | Author: [Cihat Gündüz](https://github.com/Jeehut)
 ### Deprecated
 - None.
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,31 +44,31 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 
 ## [3.1.0] - 2019-09-01
 ### Added
-- New `Comparable.clamped(to:)` and `Comparable.clamp(to:)` interfaces for any `Comparable`, e. g. `Int`.
-
+- New `Comparable.clamped(to:)` and `Comparable.clamp(to:)` interfaces for any `Comparable`, e. g. `Int`.  
+  
 ## [3.0.0] - 2019-04-30
 ### Added
-- New `Withable` protocol to init/copy objects and set properties in a convenient way on a single line.
+- New `Withable` protocol to init/copy objects and set properties in a convenient way on a single line.  
 ### Changed
-- Upgraded to Swift 5 & Xcode 10.2.
+- Upgraded to Swift 5 & Xcode 10.2.  
 ### Removed
-- Remove `ExpressibleByStringLiteral` conformance of `Regex` type to only allow initialization via `init(_:options:) throws` interface.
-
+- Remove `ExpressibleByStringLiteral` conformance of `Regex` type to only allow initialization via `init(_:options:) throws` interface.  
+  
 ## [2.8.0] - 2019-02-11
 ### Added
-- New `NSRange(_:in:)` initializer for converting from `Range<String.Index>`
-- New `sum` computed property on `Sequence` types like `Array`
-- New `average` computed property on `Collection` types with `Int` or `Double` elements like `[Int]`
-- New `fullRange` and `fullNSRange` computed properties on `String`
+- New `NSRange(_:in:)` initializer for converting from `Range<String.Index>`  
+- New `sum` computed property on `Sequence` types like `Array`  
+- New `average` computed property on `Collection` types with `Int` or `Double` elements like `[Int]`  
+- New `fullRange` and `fullNSRange` computed properties on `String`  
 ### Changed
-- Made some APIs available in wider contexts (like `sample` in `RandomAccessCollection` instead of `Array`)
-
+- Made some APIs available in wider contexts (like `sample` in `RandomAccessCollection` instead of `Array`)  
+  
 ## [2.7.0] - 2018-09-27
 ### Added
-- Official support for Linux & Swift Package Manager.
+- Official support for Linux & Swift Package Manager.  
 ### Removed
-- Support for Swift 4.1 and lower was dropped.
-
+- Support for Swift 4.1 and lower was dropped.  
+  
 ## [2.6.0] - 2018-04-22
 ### Added
-- New swifty `Regex` type built on top of the NSRegularExpression API.
+- New swifty `Regex` type built on top of the NSRegularExpression API.  

--- a/HandySwift.xcodeproj/project.pbxproj
+++ b/HandySwift.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		2E18B296242DF436000C7776 /* NSObjectExtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E18B295242DF436000C7776 /* NSObjectExtTests.swift */; };
 		2E18B297242DF436000C7776 /* NSObjectExtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E18B295242DF436000C7776 /* NSObjectExtTests.swift */; };
 		2E18B298242DF436000C7776 /* NSObjectExtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E18B295242DF436000C7776 /* NSObjectExtTests.swift */; };
+		2E61DF7A249E1CA9000AF3C5 /* Withable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E61DF79249E1CA9000AF3C5 /* Withable.swift */; };
+		2E61DF7B249E1CA9000AF3C5 /* Withable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E61DF79249E1CA9000AF3C5 /* Withable.swift */; };
+		2E61DF7C249E1CA9000AF3C5 /* Withable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E61DF79249E1CA9000AF3C5 /* Withable.swift */; };
+		2E61DF7E249E1D37000AF3C5 /* WithableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E61DF7D249E1D37000AF3C5 /* WithableTests.swift */; };
+		2E61DF7F249E1D37000AF3C5 /* WithableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E61DF7D249E1D37000AF3C5 /* WithableTests.swift */; };
+		2E61DF80249E1D37000AF3C5 /* WithableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E61DF7D249E1D37000AF3C5 /* WithableTests.swift */; };
 		3F95C8D220F22A3C0045AFD0 /* CollectionExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95C8D120F22A3C0045AFD0 /* CollectionExt.swift */; };
 		3F95C8D520F22DEE0045AFD0 /* CollectionExtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95C8D320F22DC60045AFD0 /* CollectionExtTests.swift */; };
 		3F95C8D620F22DEF0045AFD0 /* CollectionExtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F95C8D320F22DC60045AFD0 /* CollectionExtTests.swift */; };
@@ -30,12 +36,6 @@
 		823B2B3C1C24AAB7007B3CDD /* HandySwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 823B2B311C24AAB6007B3CDD /* HandySwift.framework */; };
 		823B2B4D1C24ABA4007B3CDD /* IntExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823B2B4C1C24ABA4007B3CDD /* IntExt.swift */; };
 		823B2B501C24AC00007B3CDD /* IntExtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823B2B4F1C24AC00007B3CDD /* IntExtTests.swift */; };
-		8251AA2022786D460022B277 /* Withable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251AA1F22786D460022B277 /* Withable.swift */; };
-		8251AA2122786D460022B277 /* Withable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251AA1F22786D460022B277 /* Withable.swift */; };
-		8251AA2222786D460022B277 /* Withable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251AA1F22786D460022B277 /* Withable.swift */; };
-		8251AA25227875C00022B277 /* WithableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251AA24227875C00022B277 /* WithableTests.swift */; };
-		8251AA26227875C00022B277 /* WithableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251AA24227875C00022B277 /* WithableTests.swift */; };
-		8251AA27227875C00022B277 /* WithableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8251AA24227875C00022B277 /* WithableTests.swift */; };
 		8258E4561C2E0C140031CBFF /* SortedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8258E4551C2E0C140031CBFF /* SortedArray.swift */; };
 		8258E4591C2E1ACE0031CBFF /* SortedArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8258E4581C2E1ACE0031CBFF /* SortedArrayTests.swift */; };
 		825EFDD41C3333B000558497 /* HandySwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 825EFDCA1C3333B000558497 /* HandySwift.framework */; };
@@ -142,6 +142,8 @@
 		2E18B291242DECCA000C7776 /* NSObjectExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectExt.swift; sourceTree = "<group>"; };
 		2E18B295242DF436000C7776 /* NSObjectExtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectExtTests.swift; sourceTree = "<group>"; };
 		2E4189DB231B971E00C65B81 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		2E61DF79249E1CA9000AF3C5 /* Withable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Withable.swift; sourceTree = "<group>"; };
+		2E61DF7D249E1D37000AF3C5 /* WithableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithableTests.swift; sourceTree = "<group>"; };
 		3F95C8D120F22A3C0045AFD0 /* CollectionExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExt.swift; sourceTree = "<group>"; };
 		3F95C8D320F22DC60045AFD0 /* CollectionExtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtTests.swift; sourceTree = "<group>"; };
 		63651F8F231BFF2000E022DA /* DivisibleArithmetic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisibleArithmetic.swift; sourceTree = "<group>"; };
@@ -157,8 +159,6 @@
 		823B2B421C24AAB7007B3CDD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		823B2B4C1C24ABA4007B3CDD /* IntExt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntExt.swift; sourceTree = "<group>"; };
 		823B2B4F1C24AC00007B3CDD /* IntExtTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntExtTests.swift; sourceTree = "<group>"; };
-		8251AA1F22786D460022B277 /* Withable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Withable.swift; sourceTree = "<group>"; };
-		8251AA24227875C00022B277 /* WithableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithableTests.swift; sourceTree = "<group>"; };
 		8258E4551C2E0C140031CBFF /* SortedArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedArray.swift; sourceTree = "<group>"; };
 		8258E4581C2E1ACE0031CBFF /* SortedArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortedArrayTests.swift; sourceTree = "<group>"; };
 		825EFDCA1C3333B000558497 /* HandySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HandySwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -325,7 +325,7 @@
 			isa = PBXGroup;
 			children = (
 				63651F8F231BFF2000E022DA /* DivisibleArithmetic.swift */,
-				8251AA1F22786D460022B277 /* Withable.swift */,
+				2E61DF79249E1CA9000AF3C5 /* Withable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -333,7 +333,7 @@
 		8251AA23227875A10022B277 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				8251AA24227875C00022B277 /* WithableTests.swift */,
+				2E61DF7D249E1D37000AF3C5 /* WithableTests.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -774,9 +774,9 @@
 				823B2B4D1C24ABA4007B3CDD /* IntExt.swift in Sources */,
 				CC66E047228199A0007ABF61 /* ComparableExt.swift in Sources */,
 				C5C89B9420B0A0C10048B07C /* Weak.swift in Sources */,
-				8251AA2022786D460022B277 /* Withable.swift in Sources */,
 				82CAE2921C2ED1A200F934A7 /* StringExt.swift in Sources */,
 				82CAE2961C2EE64900F934A7 /* ArrayExt.swift in Sources */,
+				2E61DF7A249E1CA9000AF3C5 /* Withable.swift in Sources */,
 				C5CFB6AC20B0A70300830511 /* Unowned.swift in Sources */,
 				82812A9B1D06877B00CD5B6C /* Globals.swift in Sources */,
 				63651F90231BFF2000E022DA /* DivisibleArithmetic.swift in Sources */,
@@ -792,8 +792,8 @@
 				826F69B01C389DB800B2CC6B /* FrequencyTableTests.swift in Sources */,
 				827599641E520FB800787F99 /* DispatchTimeIntervalExtTests.swift in Sources */,
 				8258E4591C2E1ACE0031CBFF /* SortedArrayTests.swift in Sources */,
+				2E61DF7E249E1D37000AF3C5 /* WithableTests.swift in Sources */,
 				A11830D71E58A11D00CBE087 /* TimeIntervalExtTests.swift in Sources */,
-				8251AA25227875C00022B277 /* WithableTests.swift in Sources */,
 				823B2B501C24AC00007B3CDD /* IntExtTests.swift in Sources */,
 				82CAE2941C2ED5E000F934A7 /* StringExtTests.swift in Sources */,
 				82CAE2981C2EE95200F934A7 /* ArrayExtTests.swift in Sources */,
@@ -821,9 +821,9 @@
 				82E21E8E211AF9960061EB1B /* CollectionExt.swift in Sources */,
 				CC66E048228199DE007ABF61 /* ComparableExt.swift in Sources */,
 				C5CFB6AF20B0A78F00830511 /* Weak.swift in Sources */,
-				8251AA2122786D460022B277 /* Withable.swift in Sources */,
 				A1F221651E3CC05100419B06 /* DispatchTimeIntervalExt.swift in Sources */,
 				825EFE021C33358400558497 /* SortedArray.swift in Sources */,
+				2E61DF7B249E1CA9000AF3C5 /* Withable.swift in Sources */,
 				825EFE031C33358400558497 /* IntExt.swift in Sources */,
 				82812A9C1D06877B00CD5B6C /* Globals.swift in Sources */,
 				63651F91231BFF2000E022DA /* DivisibleArithmetic.swift in Sources */,
@@ -839,8 +839,8 @@
 				826F69B11C389DB800B2CC6B /* FrequencyTableTests.swift in Sources */,
 				827599651E520FB800787F99 /* DispatchTimeIntervalExtTests.swift in Sources */,
 				825EFE111C3335A400558497 /* StringExtTests.swift in Sources */,
+				2E61DF7F249E1D37000AF3C5 /* WithableTests.swift in Sources */,
 				A11830D81E58A11D00CBE087 /* TimeIntervalExtTests.swift in Sources */,
-				8251AA26227875C00022B277 /* WithableTests.swift in Sources */,
 				825EFE0E1C3335A400558497 /* SortedArrayTests.swift in Sources */,
 				825EFE121C3335A400558497 /* ArrayExtTests.swift in Sources */,
 				825EFE0F1C3335A400558497 /* IntExtTests.swift in Sources */,
@@ -868,9 +868,9 @@
 				82E21E8F211AF9970061EB1B /* CollectionExt.swift in Sources */,
 				CC66E049228199DF007ABF61 /* ComparableExt.swift in Sources */,
 				C5CFB6B020B0A79000830511 /* Weak.swift in Sources */,
-				8251AA2222786D460022B277 /* Withable.swift in Sources */,
 				A1F221661E3CC05100419B06 /* DispatchTimeIntervalExt.swift in Sources */,
 				825EFE081C33358500558497 /* SortedArray.swift in Sources */,
+				2E61DF7C249E1CA9000AF3C5 /* Withable.swift in Sources */,
 				825EFE091C33358500558497 /* IntExt.swift in Sources */,
 				82812A9D1D06877B00CD5B6C /* Globals.swift in Sources */,
 				63651F92231BFF2800E022DA /* DivisibleArithmetic.swift in Sources */,
@@ -886,8 +886,8 @@
 				826F69B21C389DB800B2CC6B /* FrequencyTableTests.swift in Sources */,
 				827599661E520FB800787F99 /* DispatchTimeIntervalExtTests.swift in Sources */,
 				825EFE171C3335A500558497 /* StringExtTests.swift in Sources */,
+				2E61DF80249E1D37000AF3C5 /* WithableTests.swift in Sources */,
 				A11830D91E58A11D00CBE087 /* TimeIntervalExtTests.swift in Sources */,
-				8251AA27227875C00022B277 /* WithableTests.swift in Sources */,
 				825EFE141C3335A500558497 /* SortedArrayTests.swift in Sources */,
 				825EFE181C3335A500558497 /* ArrayExtTests.swift in Sources */,
 				825EFE151C3335A500558497 /* IntExtTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 </p>
 
 <p align="center">
-    <a href="https://app.bitrise.io/app/cbc4cab821708298">
-        <img src="https://app.bitrise.io/app/cbc4cab821708298/status.svg?token=1fWFE7UCuTBoYTGf4StnFQ&branch=main"
-             alt="Build Status">
+    <a href="https://github.com/Flinesoft/HandySwift/actions?query=branch%3Amain">
+        <img src="https://github.com/Flinesoft/HandySwift/workflows/CI/badge.svg"
+             alt="CI">
     </a>
     <a href="https://www.codacy.com/gh/Flinesoft/HandySwift">
         <img src="https://api.codacy.com/project/badge/Grade/f15d85eb68244c8f8c35af88ace3cdd0"

--- a/README.md
+++ b/README.md
@@ -573,18 +573,15 @@ Simple protocol to make constructing and modifying objects with multiple propert
 
 ``` swift
 struct Foo: Withable {
-    var bar: Int = 0
-    var baz: Bool = false
+    var bar: Int
+    var isEasy: Bool = false
 }
 
-// Construct a foo, setting an arbitrary subset of properties
-let foo = Foo { $0.bar = 5 }
+let defaultFoo = Foo(bar: 5)
+let customFoo = Foo(bar: 5).with { $0.isEasy = true }
 
-// Make a copy of foo, overriding an arbitrary subset of properties
-let foo2 = foo.with { $0.bar = 7; $0.baz = true }
-
-foo.bar // => 5
-foo2.bar // => 7
+foo.isEasy // => false
+foo2.isEasy // => true
 ```
 
 

--- a/Sources/HandySwift/Protocols/Withable.swift
+++ b/Sources/HandySwift/Protocols/Withable.swift
@@ -1,20 +1,10 @@
-// Copyright © 2019 Flinesoft. All rights reserved.
+// Copyright © 2020 Flinesoft. All rights reserved.
 
-/// Simple protocol to make constructing and modifying objects with multiple properties more pleasant (functional, chainable, point-free).
-public protocol Withable {
-    /// Default initializer without parameters to support Withable protocol.
-    init()
-}
+/// Simple protocol to make modifying objects with multiple properties more pleasant (functional, chainable, point-free).
+public protocol Withable { /* no requirements */ }
 
 extension Withable {
-    /// Construct a new instance, setting an arbitrary subset of properties.
-    @inlinable
-    public init(with config: (inout Self) -> Void) {
-        self.init()
-        config(&self)
-    }
-
-    /// Create a copy, overriding an arbitrary subset of properties.
+    /// Create a copy (if a struct) or use same object (if class), improving chainability e.g. after init method.
     @inlinable
     public func with(_ config: (inout Self) -> Void) -> Self {
         var copy = self

--- a/Sources/HandySwift/Protocols/Withable.swift
+++ b/Sources/HandySwift/Protocols/Withable.swift
@@ -4,6 +4,12 @@
 public protocol Withable { /* no requirements */ }
 
 extension Withable {
+    @available(*, unavailable, message: "Add `().with` after the type name, e.g. `Foo().with { $0.bar = 5 }` instead of `Foo { $0.bar = 5 }`.")
+    @inlinable
+    public init(with config: (inout Self) -> Void) { // swiftlint:disable:this missing_docs
+        fatalError("Function no longer available. Xcode should actually show an unavailable error with message and not compile.")
+    }
+
     /// Create a copy (if a struct) or use same object (if class), improving chainability e.g. after init method.
     @inlinable
     public func with(_ config: (inout Self) -> Void) -> Self {

--- a/Sources/HandySwift/Structs/Regex.swift
+++ b/Sources/HandySwift/Structs/Regex.swift
@@ -210,11 +210,8 @@ extension Regex {
                 }
 
             return captureRanges.map { [unowned self] captureRange in
-                if let captureRange = captureRange {
-                    return String(describing: self.baseString[captureRange])
-                }
-
-                return nil
+                guard let captureRange = captureRange else { return nil }
+                return String(describing: self.baseString[captureRange])
             }
         }()
 

--- a/Sources/HandySwift/Structs/SortedArray.swift
+++ b/Sources/HandySwift/Structs/SortedArray.swift
@@ -49,8 +49,8 @@ public struct SortedArray<Element: Comparable> {
         // cover trivial cases
         guard !array.isEmpty else { return nil }
         // swiftlint:disable all
-        if let first = array.first, predicate(first) { return array.startIndex }
-        if let last = array.last, !predicate(last) { return nil }
+        if let first = array.first, predicate(first) { return array.startIndex } // AnyLint.skipHere: IfAsGuard
+        if let last = array.last, !predicate(last) { return nil } // AnyLint.skipHere: IfAsGuard
         // swiftlint:enable all
 
         // binary search for first matching element

--- a/Tests/HandySwiftTests/Protocols/WithableTests.swift
+++ b/Tests/HandySwiftTests/Protocols/WithableTests.swift
@@ -1,22 +1,16 @@
-// Copyright © 2019 Flinesoft. All rights reserved.
+// Copyright © 2020 Flinesoft. All rights reserved.
 
 @testable import HandySwift
 import XCTest
 
 private struct TextFile: Withable {
-    var contents: String = ""
-    var linesCount: Int = 0
+    var contents: String
+    var linesCount: Int
 }
 
 class WithableTests: XCTestCase {
-    func testInitWith() {
-        let textFile = TextFile { $0.contents = "Text"; $0.linesCount = 5 }
-        XCTAssertEqual(textFile.contents, "Text")
-        XCTAssertEqual(textFile.linesCount, 5)
-    }
-
     func testWith() {
-        let textFile = TextFile()
+        let textFile = TextFile(contents: "", linesCount: 0)
         XCTAssertEqual(textFile.contents, "")
         XCTAssertEqual(textFile.linesCount, 0)
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import HandySwiftTests
@@ -133,7 +133,6 @@ extension TimeIntervalExtTests {
 
 extension WithableTests {
     static var allTests: [(String, (WithableTests) -> () throws -> Void)] = [
-        ("testInitWith", testInitWith),
         ("testWith", testWith)
     ]
 }

--- a/lint.swift
+++ b/lint.swift
@@ -1,0 +1,547 @@
+#!/usr/local/bin/swift-sh
+import AnyLint // @Flinesoft ~> 0.8.2
+
+try Lint.logSummaryAndExit(arguments: CommandLine.arguments) {
+	// MARK: - Variables
+	let swiftFiles: Regex = #"^Sources/.*\.swift$"#
+	let testFiles: Regex = #"^Tests/.*\.swift$"#
+  let readmeFile: Regex = #"README\.md"#
+  let changelogFile: Regex = #"^CHANGELOG\.md$"#
+
+	// MARK: - Checks
+  // MARK: Changelog
+    try Lint.checkFilePaths(
+        checkInfo: "Changelog: Each project should have a CHANGELOG.md file, tracking the changes within a project over time.",
+        regex: changelogFile,
+        matchingExamples: ["CHANGELOG.md"],
+        nonMatchingExamples: ["CHANGELOG.markdown", "Changelog.md", "ChangeLog.md"],
+        violateIfNoMatchesFound: true
+    )
+
+    // MARK: ChangelogEntryTrailingWhitespaces
+    try Lint.checkFileContents(
+        checkInfo: "ChangelogEntryTrailingWhitespaces: The summary line of a Changelog entry should end with two whitespaces.",
+        regex: #"\n([-–] (?!None\.).*[^ ])( {0,1}| {3,})\n"#,
+        matchingExamples: ["\n- Fixed a bug.\n  Issue:", "\n- Added a new option. (see [Link](#)) \nPR:"],
+        nonMatchingExamples: ["\n- Fixed a bug.  \n  Issue:", "\n- Added a new option. (see [Link](#))  \nPR:"],
+        includeFilters: [changelogFile],
+        autoCorrectReplacement: "\n$1  \n",
+        autoCorrectExamples: [
+            ["before": "\n- Fixed a bug.\n  Issue:", "after": "\n- Fixed a bug.  \n  Issue:"],
+            ["before": "\n- Fixed a bug. \n  Issue:", "after": "\n- Fixed a bug.  \n  Issue:"],
+            ["before": "\n- Fixed a bug.   \n  Issue:", "after": "\n- Fixed a bug.  \n  Issue:"],
+            ["before": "\n- Fixed a bug !\n  Issue:", "after": "\n- Fixed a bug !  \n  Issue:"],
+            ["before": "\n- Fixed a bug ! \n  Issue:", "after": "\n- Fixed a bug !  \n  Issue:"],
+            ["before": "\n- Fixed a bug !  \n  Issue:", "after": "\n- Fixed a bug !  \n  Issue:"],
+        ]
+    )
+
+    // MARK: ChangelogEntryLeadingWhitespaces
+    try Lint.checkFileContents(
+        checkInfo: "ChangelogEntryLeadingWhitespaces: The links line of a Changelog entry should start with two whitespaces.",
+        regex: #"\n( {0,1}| {3,})(Tasks?:|Issues?:|PRs?:|Authors?:)"#,
+        matchingExamples: ["\n- Fixed a bug.\nIssue: [Link](#)", "\n- Fixed a bug. \nIssue: [Link](#)", "\n- Fixed a bug.    \nIssue: [Link](#)"],
+        nonMatchingExamples: ["- Fixed a bug.\n  Issue: [Link](#)"],
+        includeFilters: [changelogFile],
+        autoCorrectReplacement: "\n  $2",
+        autoCorrectExamples: [
+            ["before": "\n- Fixed a bug.\nIssue: [Link](#)", "after": "\n- Fixed a bug.\n  Issue: [Link](#)"],
+            ["before": "\n- Fixed a bug.\n Issue: [Link](#)", "after": "\n- Fixed a bug.\n  Issue: [Link](#)"],
+            ["before": "\n- Fixed a bug.\n    Issue: [Link](#)", "after": "\n- Fixed a bug.\n  Issue: [Link](#)"],
+        ]
+    )
+
+    // MARK: ClosureParamsParantheses
+    try Lint.checkFileContents(
+        checkInfo: "ClosureParamsParantheses: Don't use parantheses around non-typed parameters in a closure.",
+        regex: #"\{\s*\(((?!self)[^):]+)\)\s*in"#,
+        matchingExamples: ["run { (a) in", "run { (a, b) in", "run { (a, b, c) in"],
+        nonMatchingExamples: ["run { (a: Int) in", "run { (a: Int, b: Int) in", "run { (a, b) -> String in"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: #"{ $1 in"#,
+        autoCorrectExamples: [
+            ["before": "run { (a) in", "after": "run { a in"],
+            ["before": "run { (a, b) in", "after": "run { a, b in"],
+            ["before": "run { (a, b, c) in", "after": "run { a, b, c in"]
+        ]
+    )
+
+    // MARK: EmptyMethodBody
+    try Lint.checkFileContents(
+        checkInfo: "EmptyMethodBody: Don't use whitespace or newlines for the body of empty methods.",
+        regex: ["declaration": #"(init|func [^\(\s]+)\([^{}]*\)"#, "spacing": #"\s*"#, "body": #"\{\s+\}"#],
+        matchingExamples: [
+            "init() { }",
+            "init() {\n\n}",
+            "init(\n    x: Int,\n    y: Int\n) { }",
+            "func foo2bar()  { }",
+            "func foo2bar(x: Int, y: Int)  { }",
+            "func foo2bar(\n    x: Int,\n    y: Int\n) {\n    \n}"
+        ],
+        nonMatchingExamples: ["init() { /* comment */ }", "init() {}", "func foo2bar() {}", "func foo2bar(x: Int, y: Int) {}"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$declaration {}",
+        autoCorrectExamples: [
+            ["before": "init()  { }", "after": "init() {}"],
+            ["before": "init(x: Int, y: Int)  { }", "after": "init(x: Int, y: Int) {}"],
+            ["before": "init()\n{\n    \n}", "after": "init() {}"],
+            ["before": "init(\n    x: Int,\n    y: Int\n) {\n    \n}", "after": "init(\n    x: Int,\n    y: Int\n) {}"],
+            ["before": "func foo2bar()  { }", "after": "func foo2bar() {}"],
+            ["before": "func foo2bar(x: Int, y: Int)  { }", "after": "func foo2bar(x: Int, y: Int) {}"],
+            ["before": "func foo2bar()\n{\n    \n}", "after": "func foo2bar() {}"],
+            ["before": "func foo2bar(\n    x: Int,\n    y: Int\n) {\n    \n}", "after": "func foo2bar(\n    x: Int,\n    y: Int\n) {}"]
+        ]
+    )
+
+    // MARK: EmptyTodo
+    try Lint.checkFileContents(
+        checkInfo: "EmptyTodo: `// TODO:` comments should not be empty.",
+        regex: #"// TODO: ?(\[[\d\-_a-z]+\])? *\n"#,
+        matchingExamples: ["// TODO:\n", "// TODO: [2020-03-19]\n", "// TODO: [cg_2020-03-19]  \n"],
+        nonMatchingExamples: ["// TODO: refactor", "// TODO: not yet implemented", "// TODO: [cg_2020-03-19] not yet implemented"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: IfAsGuard
+    try Lint.checkFileContents(
+        checkInfo: "IfAsGuard: Don't use an if statement to just return – use guard for such cases instead.",
+        regex: #" +if [^\{\n]+\{\s*return\s*[^\}]*\}(?! *else)"#,
+        matchingExamples: [" if x == 5 { return }", " if x == 5 {\n    return nil\n}", " if x == 5 { return 500 }", " if x == 5 { return do(x: 500, y: 200) }"],
+        nonMatchingExamples: [" if x == 5 {\n    let y = 200\n    return y\n}", " if x == 5 { someMethod(x: 500, y: 200) }", " if x == 500 { return } else {"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: LateForceUnwrapping3
+    try Lint.checkFileContents(
+        checkInfo: "LateForceUnwrapping3: Don't use ? first to force unwrap later – directly unwrap within the parantheses.",
+        regex: [
+            "openingBrace": #"\("#,
+            "callPart1": #"[^\s\?\.]+"#,
+            "separator1": #"\?\."#,
+            "callPart2": #"[^\s\?\.]+"#,
+            "separator2": #"\?\."#,
+            "callPart3": #"[^\s\?\.]+"#,
+            "separator3": #"\?\."#,
+            "callPart4": #"[^\s\?\.]+"#,
+            "closingBraceUnwrap": #"\)!"#
+        ],
+        matchingExamples: ["let x = (viewModel?.user?.profile?.imagePath)!\n"],
+        nonMatchingExamples: ["call(x: (viewModel?.username)!)", "let x = viewModel!.user!.profile!.imagePath\n"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$callPart1!.$callPart2!.$callPart3!.$callPart4",
+        autoCorrectExamples: [
+            ["before": "let x = (viewModel?.user?.profile?.imagePath)!\n", "after": "let x = viewModel!.user!.profile!.imagePath\n"]
+        ]
+    )
+
+    // MARK: LateForceUnwrapping2
+    try Lint.checkFileContents(
+        checkInfo: "LateForceUnwrapping2: Don't use ? first to force unwrap later – directly unwrap within the parantheses.",
+        regex: [
+            "openingBrace": #"\("#,
+            "callPart1": #"[^\s\?\.]+"#,
+            "separator1": #"\?\."#,
+            "callPart2": #"[^\s\?\.]+"#,
+            "separator2": #"\?\."#,
+            "callPart3": #"[^\s\?\.]+"#,
+            "closingBraceUnwrap": #"\)!"#
+        ],
+        matchingExamples: ["call(x: (viewModel?.profile?.username)!)"],
+        nonMatchingExamples: ["let x = (viewModel?.user?.profile?.imagePath)!\n", "let x = viewModel!.profile!.imagePath\n"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$callPart1!.$callPart2!.$callPart3",
+        autoCorrectExamples: [
+            ["before": "let x = (viewModel?.profile?.imagePath)!\n", "after": "let x = viewModel!.profile!.imagePath\n"]
+        ]
+    )
+
+    // MARK: LateForceUnwrapping1
+    try Lint.checkFileContents(
+        checkInfo: "LateForceUnwrapping1: Don't use ? first to force unwrap later – directly unwrap within the parantheses.",
+        regex: [
+            "openingBrace": #"\("#,
+            "callPart1": #"[^\s\?\.]+"#,
+            "separator1": #"\?\."#,
+            "callPart2": #"[^\s\?\.]+"#,
+            "closingBraceUnwrap": #"\)!"#
+        ],
+        matchingExamples: ["call(x: (viewModel?.username)!)"],
+        nonMatchingExamples: ["call(x: (viewModel?.profile?.username)!)", "call(x: viewModel!.username)"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$callPart1!.$callPart2",
+        autoCorrectExamples: [
+            ["before": "call(x: (viewModel?.username)!)", "after": "call(x: viewModel!.username)"]
+        ]
+    )
+
+    // MARK: MultilineIfStructure
+    try Lint.checkFileContents(
+        checkInfo: "MultilineIfStructure: Make sure multiline if conditions are all on their own lines, indented by four spaces.",
+        regex: #"^( *)if\s*(.*,) *\n((?:.+, *\n)*) *(.*\S)\s*\{\s*"#,
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$1if\n$1    $2\n$3$1    $4\n$1{\n$1    $5",
+        autoCorrectExamples: [
+            [
+                "before": """
+                    if let employee = UserDefaults.standard.currentEmployee(),
+                        let employeeName = employeeName,
+                        let employeeEmail = employeeEmail,
+                        let recipientEmail = recipientEmail {
+                            dataExporterHelper.exportData(
+                """,
+                "after": """
+                    if
+                        let employee = UserDefaults.standard.currentEmployee(),
+                        let employeeName = employeeName,
+                        let employeeEmail = employeeEmail,
+                        let recipientEmail = recipientEmail
+                    {
+                        dataExporterHelper.exportData(
+                """
+            ],
+            [
+                "before": """
+                    if let employee = UserDefaults.standard.currentEmployee(),
+                        let recipientEmail = recipientEmail
+                    {
+                        dataExporterHelper.exportData(
+                """,
+                "after": """
+                    if
+                        let employee = UserDefaults.standard.currentEmployee(),
+                        let recipientEmail = recipientEmail
+                    {
+                        dataExporterHelper.exportData(
+                """
+            ]
+        ]
+    )
+
+    // MARK: MultilineGuardEnd
+    try Lint.checkFileContents(
+        checkInfo: "MultilineGuardEnd: Always close a multiline guard via `else {` on a new line indented like the opening `guard`.",
+        regex: #"guard\s*([^\n]*,\n)+([^\n]*\S *)else\s*\{"#,
+        matchingExamples: [
+            """
+            guard
+                let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty() else {
+                return
+            }
+            """,
+            """
+            guard let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty() else {
+                return
+            }
+            """
+        ],
+        nonMatchingExamples: [
+            """
+            guard
+                let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty()
+            else {
+                return
+            }
+            """,
+            """
+            guard let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty()
+            else {
+                return
+            }
+            """
+        ],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: MultilineGuardStart
+    try Lint.checkFileContents(
+        checkInfo: "MultilineGuardStart: Always start a multiline guard via `guard` then a line break and all expressions indented.",
+        regex: #"guard([^\n]*,\s*\n)+[^\n]*\s*else\s*\{"#,
+        matchingExamples: [
+            """
+            guard let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty()
+            else {
+                return
+            }
+            """,
+            """
+            guard let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty() else {
+                return
+            }
+            """
+        ],
+        nonMatchingExamples: [
+            """
+            guard
+                let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty()
+            else {
+                return
+            }
+            """,
+            """
+            guard
+                let collection = viewModel.myCollection(),
+                !collection.compactMap({ OtherType($0) }).isEmpty() else {
+                return
+            }
+            """
+        ],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: NavigationControllerVariableNaming
+    try Lint.checkFileContents(
+        checkInfo: "NavigationControllerVariableNaming: Always name your navigation controller variables with the suffix `NavCtrl` or just `navCtrl`.",
+        regex: #"(var|let) +(nc|navigationcontroller|navc|ncontroller|navcontroller)[ :][^\n=]*=\i"#,
+        matchingExamples: ["let nc =", "var navigationController =", "let navc =", "let ncontroller =", "var nc: MyNavigationController =", "let navController: MyNavigationController<T> = "],
+        nonMatchingExamples: ["let navCtrl =", "let navCtrl: MyViewController =", "var myNavCtrl: MyViewController<T> ="],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: NavigationControllerViewNaming
+    try Lint.checkFileContents(
+        checkInfo: "NavigationControllerViewNaming: Don't call your navigation controllers like view controllers, use the suffix `NavCtrl` or just `navCtrl`.",
+        regex: #"(var|let) +\w*(?<![Nn]avCtrl) *: *\w+NavigationController\?? *="#,
+        matchingExamples: ["let viewCtrl: UINavigationController? = activeViewController != nil ? self.activeViewController : self.portraitViewCtrl"],
+        nonMatchingExamples: ["let myNavCtrl: UINavigationController? = activeViewController != nil ? self.activeViewController : self.portraitViewCtrl"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: NilCoalescingOperator
+    try Lint.checkFileContents(
+        checkInfo: "NilCoalescingOperator: Prefer nil coalescing operator over `variable != nil ? variable! : alternative`.",
+        regex: #"(\w+)\s*!=\s*nil\s*\?\s*\1!\s*:\s*(.*)"#,
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$1 ?? $2",
+        autoCorrectExamples: [
+            [
+                "before": "    let message = errorMessage != nil ? errorMessage! : L10n.Global.Info.success\n",
+                "after": "    let message = errorMessage ?? L10n.Global.Info.success\n"
+            ],
+            [
+                "before": "param: callFunction(errorMessage != nil ? errorMessage! : L10n.Global.Info.success),\n",
+                "after": "param: callFunction(errorMessage ?? L10n.Global.Info.success),\n"
+            ]
+        ]
+    )
+
+    // MARK: SingleLineGuard
+    try Lint.checkFileContents(
+        checkInfo: "SingleLineGuard: Use a single line guard for simple checks.",
+        regex: #"guard\s*([^\{]{2,80})\s+else\s*\{\s*\n\s*(return[^\n]{0,40}|continue|fatalError\([^\n;]+\))\s*\}"#,
+        matchingExamples: ["guard x else {\n  return\n}", "guard x else {\n  return 2 * x.squared(x: {15})\n}", #"guard x else {\#n  fatalError("some message: \(x)")\#n}"#],
+        nonMatchingExamples: ["guard x else { return }", "guard x else { return 2 * x.squared(x: {15}) }", #"guard x else { fatalError("some message: \(x)") }"#],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: #"guard $1 else { $2 }"#,
+        autoCorrectExamples: [
+            ["before": "guard let x = y?.x(z: 5) else {\n  return\n}", "after": "guard let x = y?.x(z: 5) else { return }"],
+            ["before": "guard let x = y?.x(z: 5) else {\n  return 2 * x.squared(x: {15})\n}", "after": "guard let x = y?.x(z: 5) else { return 2 * x.squared(x: {15}) }"],
+            ["before": "guard let x = y?.x(z: 5)\nelse {\n  return\n}", "after": "guard let x = y?.x(z: 5) else { return }"]
+        ]
+    )
+
+    // MARK: SingletonDefaultPrivateInit
+    try Lint.checkFileContents(
+        checkInfo: "SingletonDefaultPrivateInit: Singletons with a `default` object (pseudo-singletons) should not declare init methods as private.",
+        regex: #"class +(?<TYPE>\w+)(?:<[^\>]+>)? *\{.*static let `default`(?:: *\k<TYPE>)? *= *\k<TYPE>\(.*(?<=private) init\(\m"#,
+        matchingExamples: ["class MySingleton {\n  static let `default` = MySingleton()\n\n  private init() {}\n"],
+        nonMatchingExamples: ["class MySingleton {\n  static let `default` = MySingleton()\n\n  init() {}\n"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: SingletonSharedFinal
+    try Lint.checkFileContents(
+        checkInfo: "SingletonSharedFinal: Singletons with a single object (`shared`) should be marked as final.",
+        regex: #"(?<!final )class +(?<TYPE>\w+)(?:<[^\>]+>)? *\{.*static let shared(?:: *\k<TYPE>)? *= *\k<TYPE>\(\m"#,
+        matchingExamples: ["\nclass MySingleton {\n  static let shared = MySingleton()\n\n  private init() {}\n"],
+        nonMatchingExamples: ["\nfinal class MySingleton {\n  static let shared = MySingleton()\n\n  private init() {}\n"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: SingletonSharedPrivateInit
+    try Lint.checkFileContents(
+        checkInfo: "SingletonSharedPrivateInit: Singletons with a single object (`shared`) should declare their init method(s) as private.",
+        regex: #"class +(?<TYPE>\w+)(?:<[^\>]+>)? *\{.*static let shared(?:: *\k<TYPE>)? *= *\k<TYPE>\(.*(?<= |\t|public|internal) init\(\m"#,
+        matchingExamples: ["\nfinal class MySingleton {\n  static let shared = MySingleton()\n\n  init() {}\n"],
+        nonMatchingExamples: ["\nfinal class MySingleton {\n  static let shared = MySingleton()\n\n  private init() {}\n"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: SingletonSharedSingleObject
+    try Lint.checkFileContents(
+        checkInfo: "SingletonSharedSingleObject: Singletons with a `shared` object (real Singletons) should not have other static let properties. Use `default` instead (if needed).",
+        regex: #"class +(?<TYPE>\w+)(?:<[^\>]+>)? *\{.*(?:static let shared(?:: *\k<TYPE>)? *= *\k<TYPE>\(.*static let \w+(?:: *\k<TYPE>)? *= *\k<TYPE>\(|static let \w+(?:: *\k<TYPE>)? *= *\k<TYPE>\(.*static let shared(?:: *\k<TYPE>)? *= *\k<TYPE>\()\m"#,
+        matchingExamples: ["\nfinal class MySingleton {\n  static let shared = MySingleton(url: productionUrl)\n  static let test = MySingleton(url: testUrl)"],
+        nonMatchingExamples: ["\nfinal class MySingleton {\n  static let shared = MySingleton()\n\n  private init() {}\n"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: SwitchAssociatedValueStyle
+    try Lint.checkFileContents(
+        checkInfo: "SwitchAssociatedValueStyle: Always put the `let` in front of case – even if only one associated value captured.",
+        regex: #"case +[^\(][^\n]*(\(let |[^\)], let)"#,
+        matchingExamples: ["case .addText(let text, let font, let textColor):", "case .addImage(let image)"],
+        nonMatchingExamples: ["case let .addText(text, font, textColor):", "case let .addImage(image)"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: TernaryOperatorWhitespace
+    try Lint.checkFileContents(
+        checkInfo: "TernaryOperatorWhitespace: There should be a single whitespace around each separator.",
+        regex: #"(.*\S)\s*\?\s*(\w+)\s*:\s*(.*)"#,
+        nonMatchingExamples: ["viewCtrl?.call(param: 50)"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: #"$1 ? $2 : $3"#,
+        autoCorrectExamples: [
+            ["before": "constant = singleUserMode() ? 0:28", "after": "constant = singleUserMode() ? 0 : 28"],
+            ["before": "constant = singleUserMode() ? 0 :28", "after": "constant = singleUserMode() ? 0 : 28"],
+            ["before": "constant = singleUserMode() ?0 : 28", "after": "constant = singleUserMode() ? 0 : 28"],
+            ["before": "constant = singleUserMode() ? 0: 28", "after": "constant = singleUserMode() ? 0 : 28"]
+        ]
+    )
+
+    // MARK: TodoUppercase
+    try Lint.checkFileContents(
+        checkInfo: "TodoUppercase: All TODOs should be all-uppercased like this: `// TODO: [cg_YYYY-MM-DD] `.",
+        regex: #"// ?(tODO|ToDO|TOdO|TODo|todo|Todo|ToDo|toDo)"#,
+        matchingExamples: ["// todo: ", "// toDo: ", "// Todo: ", "// ToDo: ", "//todo: "],
+        nonMatchingExamples: ["// TODO: ", "//TODO: "],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: #"// TODO"#,
+        autoCorrectExamples: [
+            ["before": "// todo: ", "after": "// TODO: "],
+            ["before": "// toDo: ", "after": "// TODO: "],
+            ["before": "// Todo: ", "after": "// TODO: "],
+            ["before": "// ToDo: ", "after": "// TODO: "],
+            ["before": "//todo: ", "after": "// TODO: "]
+        ]
+    )
+
+    // MARK: TodoWhitespacing
+    try Lint.checkFileContents(
+        checkInfo: "TodoWhitespacing: All TODOs should exactly start like this (mind the whitespacing): `// TODO: `.",
+        regex: #"//TODO: *|// TODO:(?=[^ ])|// TODO: {2,}|// {2,}TODO: *|// TODO +|// TODO *(?=\n)"#,
+        matchingExamples: ["//TODO: foo", "// TODO foo", "// TODO:foo", "// TODO:   foo", "{\n    // TODO\n}   "],
+        nonMatchingExamples: ["// TODO: foo", "// TODO: [cg_2020-02-24] foo"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: #"// TODO: "#,
+        autoCorrectExamples: [
+            ["before": "//TODO: foo", "after": "// TODO: foo"],
+            ["before": "// TODO foo", "after": "// TODO: foo"],
+            ["before": "// TODO:foo", "after": "// TODO: foo"],
+            ["before": "// TODO:   foo", "after": "// TODO: foo"],
+            ["before": "{\n    // TODO\n}   ", "after": "{\n    // TODO: \n}   "]
+        ]
+    )
+
+    // MARK: TupleIndex
+    try Lint.checkFileContents(
+        checkInfo: "TupleIndex: Prevent unwrapping tuples by their index – define a typealias with named components instead.",
+        regex: #"(\$\d|\w*[^%\d \(\[\{])\.\d[^\w]"#,
+        matchingExamples: ["$0.0 ", "$1.2,", "tuple.0)"],
+        nonMatchingExamples: ["$0.key ", "tuple.key,", "%1$d of %2$d)"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: UnnecessaryNilAssignment
+    try Lint.checkFileContents(
+        checkInfo: "UnnecessaryNilAssignment: Don't assign nil as a value when defining an optional type – it's nil by default.",
+        regex: #"(\svar +\w+\s*:\s*[^\n=]+\?)\s*=\s*nil"#,
+        matchingExamples: ["class MyClass {\n  var count: Int? = nil\n", "class MyClass {\n  var dict: Dictionary<String, AnyObject>? = nil\n"],
+        nonMatchingExamples: ["class MyClass {\n  let count: Int? = nil\n", "funct sum(dict: Dictionary<String, AnyObject>? = nil,"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$1",
+        autoCorrectExamples: [
+            ["before": "class MyClass {\n  var  count:Int?=nil\n", "after": "class MyClass {\n  var  count:Int?\n"],
+            ["before": "class MyClass {\n  var dict: Dictionary<String, AnyObject>? = nil\n", "after": "class MyClass {\n  var dict: Dictionary<String, AnyObject>?\n"]
+        ]
+    )
+
+    // MARK: ViewControllerVariableNaming
+    try Lint.checkFileContents(
+        checkInfo: "ViewControllerVariableNaming: Always name your view controller variables with the suffix `ViewCtrl` or just `viewCtrl`.",
+        regex: #"(var|let) +(vc|viewcontroller|viewc|vcontroller)[ :][^\n=]*=\i"#,
+        matchingExamples: ["let vc =", "var viewController =", "let viewc =", "let vcontroller =", "var vc: MyViewController =", "let viewController: MyViewController<T> = "],
+        nonMatchingExamples: ["let viewCtrl =", "let viewCtrl: MyViewController =", "var myViewCtrl: MyViewController<T> ="],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles]
+    )
+
+    // MARK: WhitespaceAfterRangeOperators
+    try Lint.checkFileContents(
+        checkInfo: "WhitespaceAfterRangeOperators: A range operator should be surrounded by a single whitespace.",
+        regex: #"(\w) *(\.\.[<\.])(\w)"#,
+        matchingExamples: ["5..<7", "x ..<y", "x ...y", "x...y"],
+        nonMatchingExamples: ["5 ..< 7", "5 ... 7", "x ..< y", "x ... y", "// comment ...\n  class"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$1 $2 $3",
+        autoCorrectExamples: [
+            ["before": "5...7", "after": "5 ... 7"],
+            ["before": "x..<y", "after": "x ..< y"],
+            ["before": "5 ..<7", "after": "5 ..< 7"]
+        ]
+    )
+
+    // MARK: WhitespaceBeforeComment
+    try Lint.checkFileContents(
+        checkInfo: "WhitespaceBeforeComment: A comment should always be preceded by a single whitespace if on a code line.",
+        regex: #"([^:\s/])(?: {0}| {2,})//"#,
+        matchingExamples: ["let x = 5// foo", "}//foo", "]  //    foo", "]/// foo"],
+        nonMatchingExamples: ["let x = 5 // foo", "} //foo", "] //   foo", "\n  /// foo", #"URL(string: "https://flinesoft.com")"#],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$1 //",
+        autoCorrectExamples: [
+            ["before": "let x = 5// foo", "after": "let x = 5 // foo"],
+            ["before": "}//foo", "after": "} //foo"],
+            ["before": "]  //    foo", "after": "] //    foo"]
+        ]
+    )
+
+    // MARK: WhitespaceBeforeRangeOperators
+    try Lint.checkFileContents(
+        checkInfo: "WhitespaceBeforeRangeOperators: A range operator should be surrounded by a single whitespace.",
+        regex: #"(\w)(\.\.[<\.]) *(\w)"#,
+        matchingExamples: ["5..<7", "5..< 7", "x...y"],
+        nonMatchingExamples: ["5 ..< 7", "5 ... 7", "x ..< y", "x ... y", "// comment ... \n  class"],
+        includeFilters: [swiftFiles],
+        excludeFilters: [testFiles],
+        autoCorrectReplacement: "$1 $2 $3",
+        autoCorrectExamples: [
+            ["before": "5...7", "after": "5 ... 7"],
+            ["before": "x..<y", "after": "x ..< y"],
+            ["before": "x..< y", "after": "x ..< y"]
+        ]
+    )
+}


### PR DESCRIPTION
Fixes #49.

## Proposed Changes

  - Remove the `init()` requirement from `Withable`.
  - Remove the `init` syntax sugar method that allowed `Foo { $0.bar = 5}` in favor of `Foo().with { $0.bar = 5}`.
  - Adds support for `Foo(bar: 5).with { $0.otherProperty = true }` without requiring `init()` on `Foo` type.
